### PR TITLE
Staticman v3 POST URL & enable custom API instance

### DIFF
--- a/layouts/partials/staticman/form-comments.html
+++ b/layouts/partials/staticman/form-comments.html
@@ -14,7 +14,7 @@
 
 <div id="comment-form">
   <h1 id="comment-form-header">Say something</h1>
-  <form method="POST" action="https://dev.staticman.net/v3/entry/github/{{ .Site.Params.staticman.username }}/{{ .Site.Params.staticman.repository }}/{{ .Site.Params.staticman.branch }}/comments">
+  <form method="POST" action="https://{{ .Site.Params.staticman.baseurl }}/v3/entry/{{ .Site.Params.staticman.gitprovider }}/{{ .Site.Params.staticman.username }}/{{ .Site.Params.staticman.repository }}/{{ .Site.Params.staticman.branch }}/comments">
     <input type="hidden" name="options[redirect]" value="{{ .Permalink }}#comment-submitted">
     <input type="hidden" name="options[redirectError]" value="{{ .Permalink }}#comment-error">
     <input type="hidden" name="options[slug]" value="{{ .File.ContentBaseName  }}">


### PR DESCRIPTION
# Descrption

Added two site parameters

1. `.Site.Params.staticman.baseurl`: base URL of custom Staticman instance
2. `{{ .Site.Params.staticman.gitprovider }}`: Git provider for the target Git* repo, takes either `github` or `gitlab` as value

:link: https://staticman.net/docs/getting-started.html

![Screenshot from 2021-02-26 11-33-32](https://user-images.githubusercontent.com/5748535/109292068-1ae35e00-782a-11eb-9f97-5dfd2bfd2d0f.png)

:warning: `dev.staticman.net` is no longer working.